### PR TITLE
September Security Patch

### DIFF
--- a/src/codec/SkPngCodec.cpp
+++ b/src/codec/SkPngCodec.cpp
@@ -952,7 +952,7 @@ void AutoCleanPng::infoCallback(size_t idatLength) {
                     imageInfo = imageInfo.makeColorType(kAlpha_8_SkColorType);
                 }
             }
-        } else if (SkEncodedInfo::kOpaque_Alpha == alpha) {
+        } else if (encodedColorType == PNG_COLOR_TYPE_RGB) {
             png_color_8p sigBits;
             if (png_get_sBIT(fPng_ptr, fInfo_ptr, &sigBits)) {
                 if (5 == sigBits->red && 6 == sigBits->green && 5 == sigBits->blue) {
@@ -961,6 +961,18 @@ void AutoCleanPng::infoCallback(size_t idatLength) {
                 }
             }
         }
+
+#ifdef SK_BUILD_FOR_ANDROID_FRAMEWORK
+        if (encodedColorType != PNG_COLOR_TYPE_GRAY_ALPHA
+            && SkEncodedInfo::kOpaque_Alpha == alpha) {
+            png_color_8p sigBits;
+            if (png_get_sBIT(fPng_ptr, fInfo_ptr, &sigBits)) {
+                if (5 == sigBits->red && 6 == sigBits->green && 5 == sigBits->blue) {
+                    SkAndroidFrameworkUtils::SafetyNetLog("190188264");
+                }
+            }
+        }
+#endif // SK_BUILD_FOR_ANDROID_FRAMEWORK
 
         if (1 == numberPasses) {
             *fOutCodec = new SkPngNormalDecoder(encodedInfo, imageInfo,


### PR DESCRIPTION
Bug: 190188264
Bug: skia:5616
Test: imagedecoder_png_fuzzer
Test: Codec_PngRoundTrip

If a PNG's sBIT specifies that the significant bits are 565, SkPngCodec
treats the image as defaulting to kRGB_565_SkColorType, rather than the
typical kN32_SkColorType. This feature is likely rarely used in the
wild, but it is used by Skia to encode kRGB_565_SkColorType to a PNG and
then recreate the original SkPixmap. These Skia-created PNGs always use
PNG_COLOR_TYPE_RGB, so only respect this sBIT with PNG_COLOR_TYPE_RGB.

Further, if the PNG is PNG_COLOR_TYPE_PALETTE, treating it as 565 means
that we read it incorrectly.

Change-Id: I15d9571398870ecf67a150e46d28d4545afcf3c8
Merged-In: I15d9571398870ecf67a150e46d28d4545afcf3c8
(cherry picked from commit 6a2a767f72c965775fa1740bfcdc57c24488ac6a)